### PR TITLE
feat: add new vue config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,35 @@ import { svelteConfig } from '@hypernym/eslint-config/svelte'
 export default [jsConfig, tsConfig, svelteConfig, ignoresConfig]
 ```
 
+### Vue/Nuxt
+
+> [!NOTE]
+>
+> Install the required `Vue` dev dependencies before using:
+>
+> ```sh
+> pnpm add -D eslint-plugin-vue
+> ```
+>
+> Also, don't forget to add the `vue` lang key to the `eslint.validate` vscode setting:
+>
+> ```js
+> // .vscode/settings.json
+>
+> {
+>   "eslint.validate": ["javascript", "typescript", "vue"]
+> }
+> ```
+
+```js
+// eslint.config.js
+
+import { jsConfig, tsConfig, ignoresConfig } from '@hypernym/eslint-config'
+import { vueConfig } from '@hypernym/eslint-config/vue'
+
+export default [jsConfig, tsConfig, vueConfig, ignoresConfig]
+```
+
 ### Custom
 
 ```js

--- a/bundler.config.ts
+++ b/bundler.config.ts
@@ -14,5 +14,15 @@ export default defineConfig({
       ],
     },
     { types: './src/types/svelte/index.ts' },
+    {
+      input: './src/vue/index.js',
+      output: './dist/vue/index.mjs',
+      externals: [
+        ...Object.keys(dependencies),
+        ...Object.keys(devDependencies),
+        'vue-eslint-parser',
+      ],
+    },
+    { types: './src/types/vue/index.ts' },
   ],
 })

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "./svelte": {
       "types": "./dist/types/svelte/index.d.ts",
       "import": "./dist/svelte/index.mjs"
+    },
+    "./vue": {
+      "types": "./dist/types/vue/index.d.ts",
+      "import": "./dist/vue/index.mjs"
     }
   },
   "files": [
@@ -45,7 +49,8 @@
     "eslint": ">=9.0.0",
     "typescript": ">=5.0.0",
     "eslint-plugin-svelte": ">=2.39.0",
-    "svelte-eslint-parser": ">=0.39.0"
+    "svelte-eslint-parser": ">=0.39.0",
+    "eslint-plugin-vue": ">=9.23.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
@@ -55,6 +60,9 @@
       "optional": true
     },
     "svelte-eslint-parser": {
+      "optional": true
+    },
+    "eslint-plugin-vue": {
       "optional": true
     }
   },
@@ -72,6 +80,7 @@
     "@hypernym/tsconfig": "^2.1.0",
     "eslint": "^9.9.1",
     "eslint-plugin-svelte": "^2.43.0",
+    "eslint-plugin-vue": "^9.28.0",
     "prettier": "^3.3.3",
     "svelte-eslint-parser": "^0.41.0",
     "typescript": "^5.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^2.43.0
         version: 2.43.0(eslint@9.9.1)
+      eslint-plugin-vue:
+        specifier: ^9.28.0
+        version: 9.28.0(eslint@9.9.1)
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -536,6 +539,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -631,6 +637,12 @@ packages:
     peerDependenciesMeta:
       svelte:
         optional: true
+
+  eslint-plugin-vue@9.28.0:
+    resolution: {integrity: sha512-ShrihdjIhOTxs+MfWun6oJWuk+g/LAhN+CiuOl/jjkG3l0F2AuK5NMTaWqyvBgkFtpYmyks6P4603mLmhNJW8g==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -736,6 +748,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -838,6 +854,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
@@ -866,6 +885,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1043,6 +1065,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
@@ -1054,6 +1080,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vue-eslint-parser@9.4.3:
+    resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1062,6 +1094,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -1457,6 +1493,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -1571,6 +1609,20 @@ snapshots:
       svelte-eslint-parser: 0.41.0
     transitivePeerDependencies:
       - ts-node
+
+  eslint-plugin-vue@9.28.0(eslint@9.9.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.1)
+      eslint: 9.9.1
+      globals: 13.24.0
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 6.1.2
+      semver: 7.6.3
+      vue-eslint-parser: 9.4.3(eslint@9.9.1)
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-scope@7.2.2:
     dependencies:
@@ -1702,6 +1754,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
   globals@14.0.0: {}
 
   globals@15.9.0: {}
@@ -1780,6 +1836,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -1804,6 +1862,10 @@ snapshots:
   nanoid@3.3.7: {}
 
   natural-compare@1.4.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   optionator@0.9.4:
     dependencies:
@@ -1965,6 +2027,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.20.2: {}
+
   typescript@5.5.4: {}
 
   uri-js@4.4.1:
@@ -1973,11 +2037,26 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vue-eslint-parser@9.4.3(eslint@9.9.1):
+    dependencies:
+      debug: 4.3.6
+      eslint: 9.9.1
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      lodash: 4.17.21
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  xml-name-validator@4.0.0: {}
 
   yaml@1.10.2: {}
 

--- a/src/ignores.js
+++ b/src/ignores.js
@@ -8,8 +8,10 @@ export const ignores = [
   '**/.svelte-kit/**/*',
   '**/.vercel/**/*',
   '**/.history/**/*',
+  '**/.netlify/**/*',
   '**/.output/**/*',
   '**/.cache/**/*',
+  '**/.nuxt/**/*',
   '**/.temp/**/*',
   '**/.tmp/**/*',
   '**/.out/**/*',
@@ -33,6 +35,7 @@ export const ignores = [
   '**/LICENSE*',
 ]
 
+/** @type {import("eslint").Linter.Config} */
 export const ignoresConfig = {
   ignores,
 }

--- a/src/types/vue/index.ts
+++ b/src/types/vue/index.ts
@@ -1,0 +1,1 @@
+export * from './vue-config'

--- a/src/types/vue/vue-config.ts
+++ b/src/types/vue/vue-config.ts
@@ -1,0 +1,3 @@
+import type { Linter } from 'eslint'
+
+export declare const vueConfig: Linter.Config

--- a/src/vue/index.js
+++ b/src/vue/index.js
@@ -1,0 +1,1 @@
+export * from './vue-config.js'

--- a/src/vue/vue-config.js
+++ b/src/vue/vue-config.js
@@ -1,0 +1,69 @@
+import globals from 'globals'
+import jsPlugin from '@eslint/js'
+import tsPlugin from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
+import vuePlugin from 'eslint-plugin-vue'
+import vueParser from 'vue-eslint-parser'
+
+/** @type {import("eslint").Linter.Config} */
+export const vueConfig = {
+  files: ['**/*.vue'],
+  languageOptions: {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+    parser: vueParser,
+    parserOptions: {
+      parser: tsParser,
+    },
+    globals: {
+      ...globals.es2021,
+      ...globals.browser,
+      ...globals.nodeBuiltin,
+      computed: 'readonly',
+      defineEmits: 'readonly',
+      defineExpose: 'readonly',
+      defineProps: 'readonly',
+      onMounted: 'readonly',
+      onUnmounted: 'readonly',
+      reactive: 'readonly',
+      ref: 'readonly',
+      shallowReactive: 'readonly',
+      shallowRef: 'readonly',
+      toRef: 'readonly',
+      toRefs: 'readonly',
+      watch: 'readonly',
+      watchEffect: 'readonly',
+      $fetch: 'readonly',
+    },
+  },
+  plugins: {
+    vue: vuePlugin,
+    '@typescript-eslint': tsPlugin,
+  },
+  rules: {
+    ...jsPlugin.configs.recommended.rules,
+    ...tsPlugin.configs.recommended.rules,
+    ...vuePlugin.configs['flat/recommended'].rules,
+    ...vuePlugin.configs['vue3-essential'].rules,
+    ...vuePlugin.configs['vue3-strongly-recommended'].rules,
+    ...vuePlugin.configs['vue3-recommended'].rules,
+    'no-undef': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { ignoreRestSiblings: true },
+    ],
+    'vue/multi-word-component-names': 'off',
+    'vue/singleline-html-element-content-newline': 'off',
+    'vue/html-self-closing': [
+      'warn',
+      {
+        html: {
+          void: 'always',
+          normal: 'never',
+          component: 'any',
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Adds new `Vue` config.

### Vue/Nuxt

> [!NOTE]
>
> Install the required `Vue` dev dependencies before using:
>
> ```sh
> pnpm add -D eslint-plugin-vue
> ```
>
> Also, don't forget to add the `vue` lang key to the `eslint.validate` vscode setting:
>
> ```js
> // .vscode/settings.json
>
> {
>   "eslint.validate": ["javascript", "typescript", "vue"]
> }
> ```

```js
// eslint.config.js

import { jsConfig, tsConfig, ignoresConfig } from '@hypernym/eslint-config'
import { vueConfig } from '@hypernym/eslint-config/vue'

export default [jsConfig, tsConfig, vueConfig, ignoresConfig]
```